### PR TITLE
Saving support for mini kappa goniometer

### DIFF
--- a/bin/crystalplan.py
+++ b/bin/crystalplan.py
@@ -1,0 +1,5 @@
+#!/bin/python
+# EASY-INSTALL-SCRIPT: 'CrystalPlan==1.2','crystalplan.py'
+__requires__ = 'CrystalPlan==1.2'
+import pkg_resources
+pkg_resources.run_script('CrystalPlan==1.2', 'crystalplan.py')

--- a/bin/mayavi2
+++ b/bin/mayavi2
@@ -1,0 +1,10 @@
+#!/bin/python
+# EASY-INSTALL-ENTRY-SCRIPT: 'mayavi==4.4.0','gui_scripts','mayavi2'
+__requires__ = 'mayavi==4.4.0'
+import sys
+from pkg_resources import load_entry_point
+
+if __name__ == '__main__':
+    sys.exit(
+        load_entry_point('mayavi==4.4.0', 'gui_scripts', 'mayavi2')()
+    )

--- a/bin/tvtk_doc
+++ b/bin/tvtk_doc
@@ -1,0 +1,10 @@
+#!/bin/python
+# EASY-INSTALL-ENTRY-SCRIPT: 'mayavi==4.4.0','gui_scripts','tvtk_doc'
+__requires__ = 'mayavi==4.4.0'
+import sys
+from pkg_resources import load_entry_point
+
+if __name__ == '__main__':
+    sys.exit(
+        load_entry_point('mayavi==4.4.0', 'gui_scripts', 'tvtk_doc')()
+    )

--- a/gui/frame_main.py
+++ b/gui/frame_main.py
@@ -530,12 +530,12 @@ class FrameMain(wx.Frame):
     #--------------------------------------------------------------------
     def _init_ctrls(self, prnt):
         wx.Frame.__init__(self, id=wxID_FRAMEMAIN, name=u'FrameMain',
-              parent=prnt, pos=wx.Point(0, 0), size=wx.Size(800, 630),
+              parent=prnt, pos=wx.Point(0, 0), size=wx.Size(800, 830),
               style=wx.DEFAULT_FRAME_STYLE,
               title="%s %s - Main Window" % (CrystalPlan_version.package_name, CrystalPlan_version.version) )
         self._init_menus()
         
-        self.SetClientSize(wx.Size(850, 630))
+        self.SetClientSize(wx.Size(850, 830))
         self.SetMenuBar(self.menuBar1)
         self.SetMinSize(wx.Size(100, 100))
         self.SetAutoLayout(True)

--- a/gui/panel_experiment.py
+++ b/gui/panel_experiment.py
@@ -16,6 +16,8 @@ import frame_optimizer
 
 #--- Model Imports ---
 import model
+import model.numpy_utils
+import numpy as np
 
 #--- Traits Imports ---
 from traits.api import HasTraits,Int,Float,Str,String,Property,Bool, List, Tuple, Array, Enum
@@ -101,8 +103,16 @@ class ExperimentGridController():
         grid.SetColSize(self.criterion_col+1, 100)
         grid.SetColLabelValue(self.criterion_col+2, "Comment")
         grid.SetColSize(self.criterion_col+2, 120)
+                
+        if model.instrument.inst.goniometer.name == 'IMAGINE mini-kappa goniometer':
+            ImagineKappa = True
+            angle_names = ['phi deg', 'kappa deg', 'omega deg']
+        else:
+            ImagineKappa = False   
+            
         for (i, anginfo) in enumerate(model.instrument.inst.angles):
-            grid.SetColLabelValue(i+1, anginfo.name + "\n(" + anginfo.friendly_units + ")")
+            x = anginfo.friendly_units if not ImagineKappa else angle_names[i]
+            grid.SetColLabelValue(i+1, anginfo.name + "\n(" + x + ")")
             grid.SetColSize(i+1, 100)
 
     #------------------------------------
@@ -123,7 +133,6 @@ class ExperimentGridController():
             for row in xrange(old_num_rows, num_rows):
                 grid.SetCellEditor(row, self.criterion_col, wx.grid.GridCellChoiceEditor(choices))
 
-
         #Font for angles
         angle_font = wx.Font(10, 76, wx.NORMAL, wx.NORMAL, False, u'Monospace')
         for (i, poscov) in enumerate(model.instrument.inst.positions):
@@ -132,9 +141,22 @@ class ExperimentGridController():
             grid.SetCellAlignment(row, 0, wx.ALIGN_CENTRE, wx.ALIGN_CENTRE )
             grid.SetReadOnly(row, 0, True) #Do set it read-only
             #The angles
+
+            if model.instrument.inst.goniometer.name == 'IMAGINE mini-kappa goniometer':
+                ImagineKappa = True
+            else:
+                ImagineKappa = False   
+                
+            if ImagineKappa:
+                phi, chi, omega = poscov.angles
+                alpha = np.deg2rad(model.instrument.inst.goniometer.alpha)
+                phi, alpha, kappa, omega = model.numpy_utils.kappa_from_euler(phi, chi, omega, alpha=alpha)
+                conv_angles = [phi, kappa, omega]
+            
             for (j, angleinfo) in enumerate(model.instrument.inst.angles):
-                x = poscov.angles[j]
+                x = poscov.angles[j] if not ImagineKappa else conv_angles[j]
                 col = j+1
+                                
                 grid.SetCellValue(row, col, u"%8.2f" % angleinfo.internal_to_friendly(x))
                 grid.SetReadOnly(row, col, True) #Do set it read-only
                 grid.SetCellAlignment(row, col, wx.ALIGN_CENTRE, wx.ALIGN_CENTRE )

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 formats = rpm
 
 [bdist_rpm]
-release = 11
+release = 12
 packager = ORNL NDAV
 #doc_files = docs/user_guide.pdf
 requires = numpy,scipy,python-traitsui,python-matplotlib-wx,Mayavi


### PR DESCRIPTION
This adds additional functionality to display and save the phi, kappa, and omega angles in the experiment table and save them to output CSV file format.

The window is also extended so that the button for switching goniometers is clearer to users.